### PR TITLE
Removed crearing keyPair on construct

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -105,8 +105,6 @@ class Guard
         $this->setStorageLimit($storageLimit);
 
         $this->setPersistentTokenMode($persistentTokenMode);
-
-        $this->keyPair = null;
     }
 
     /**


### PR DESCRIPTION
This fix is for issue https://github.com/slimphp/Slim-Csrf/issues/85
Now users can create guard in any order